### PR TITLE
remove slug from deps, replace with native replace function

### DIFF
--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _       = require('lodash');
-var slug    = require('slug');
 var path    = require('path');
 var cheerio = require('cheerio');
 
@@ -25,8 +24,8 @@ function parseFile(file, options, callback) {
     name:               name,
     viewBox:            viewBox.join(' '),
     originalAttributes: attr,
-    // Slug id because I don't like spaces in IDs or Classes XD
-    id:                 slug(name),
+
+    id:                 name.replace(/\s/g, '-'),
     // SVG files might not have size
     // https://github.com/Hiswe/gulp-svg-symbols/issues/10
     width:    utils.sizeOrViewboxFallback(attr.width, viewBox[2]),

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "consolidate": "^0.14.1",
     "gulp-util": "^3.0.7",
     "lodash": "^4.11.1",
-    "slug": "^0.9.1",
     "through2": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I've removed slug from deps, cause it has node-unicode as dep and node-unicode does not work on NodeJs 6.0. Actually, I do not know, why you use slug just to replace whitespaces. I think, native replace will be enough for that.