### PR TITLE
add hidden attribute to default template

### DIFF
--- a/templates/svg-symbols.svg
+++ b/templates/svg-symbols.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg"<% if(svgClassname) {%> class="<%= svgClassname %>"<% } %>><% if(defs) {%>
+<svg xmlns="http://www.w3.org/2000/svg" display="none" <% if(svgClassname) {%> class="<%= svgClassname %>"<% } %>><% if(defs) {%>
   <defs>
       <%= defs %>
   </defs><% } %><% _.forEach( icons, function( icon ){ %>


### PR DESCRIPTION
By adding display="hidden" in the default template, it is possible to use svg symbols without them rendering on the page.