### PR TITLE
feat: adds the ability to access defs only for a specific icon

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,6 @@ function gulpSvgSymbols(opts) {
       // defs are not at an SVG level
       // they should be handled globally to the new SVG file
       if (svgRawData.defs) defs.push(svgRawData.defs);
-      delete svgRawData.defs;
       //
       return svg.formatForTemplate(svgRawData, options);
     });


### PR DESCRIPTION
I'm generating a template that injects svg file content directly into the html source as an svg. This eliminates the 'bad' support for xlink:href, prevents downloading a big svg file, and only downloads icons on a page where they are needed.
But because I'm basically generating a switch with the (stripped) content of my svg folder I need a way to insert the defs only in those places where they are needed.

The way it is setup now is it assumes I want to generate **one** svg in one document, but I'm actually generating **several** svgs in one document. This pull request fixes that for me. Everybody still has access to the defs as expected, but also no data is removed from the raw svg data on a per-file basis.

Not sure if I'm explaining correctly, so below is some code to help me out.

Below is the desired result. Notice the absence of the `<defs>` on the 'arrow-left':
```
mixin icon(icon)
  case icon
    when "arrow-left"
      <svg xmlns="http://www.w3.org/2000/svg" class="i i-arrow-left" viewBox="0 0 17 24">
        <title>arrow-left icon</title>
         <path d="M15.27 5.095a2.985 2.985 0 0 0-4.22-4.22L0 11.923l11.036 11.187a2.985 2.985 0 1 0 4.25-4.192l-6.873-6.966 6.858-6.858z"/> 
      </svg>
    when "logo-badge"
      <svg xmlns="http://www.w3.org/2000/svg" class="i i-logo-badge" viewBox="0 0 68 68">
        <defs> <linearGradient x1="50.4%" y1="323.84%" x2="50.4%" y2="1.11%" id="a"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#0086CD" offset="100%"/> </linearGradient> <linearGradient x1="50.14%" y1="499.2%" x2="50.14%" y2="3.23%" id="b"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#556AB1" offset="100%"/> </linearGradient> <linearGradient x1="49.96%" y1="322.98%" x2="49.96%" y2="1.05%" id="c"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#8C288E" offset="100%"/> </linearGradient> <linearGradient x1="50.26%" y1="222.51%" x2="50.26%" y2="1%" id="d"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#00C0F3" offset="100%"/> </linearGradient> <linearGradient x1="50.28%" y1="205.24%" x2="50.28%" y2="-5.49%" id="e"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#EA0078" offset="100%"/> </linearGradient> </defs><title>logo-badge icon</title>
          <g> <path d="M10 0h11v68H10z"/> <path d="M18 0h22v68H18z"/> <path d="M36 0h22v68H36z"/> <path d="M0 0h12v68H0z"/> <path d="M50 0h18v68H50z"/> <path d="M28.894 41.753v15.729H16.376v-7.247h4.53V17.706h-5.435v-7.247h13.505v27.506l15.483-15.647h8.153v7.329h-4.53L37.624 39.941l10.541 10.377h5.27v7.247h-8.976z"/> </g> 
      </svg>
```
Below is the current result (notice the `<defs>` present on arrow-left as well? Don't want that!):
```
mixin icon(icon)
  case icon

    when "arrow-left"
      <svg xmlns="http://www.w3.org/2000/svg" class="i i-arrow-left" viewBox="0 0 17 24">
        <defs> <linearGradient x1="50.4%" y1="323.84%" x2="50.4%" y2="1.11%" id="a"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#0086CD" offset="100%"/> </linearGradient> <linearGradient x1="50.14%" y1="499.2%" x2="50.14%" y2="3.23%" id="b"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#556AB1" offset="100%"/> </linearGradient> <linearGradient x1="49.96%" y1="322.98%" x2="49.96%" y2="1.05%" id="c"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#8C288E" offset="100%"/> </linearGradient> <linearGradient x1="50.26%" y1="222.51%" x2="50.26%" y2="1%" id="d"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#00C0F3" offset="100%"/> </linearGradient> <linearGradient x1="50.28%" y1="205.24%" x2="50.28%" y2="-5.49%" id="e"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#EA0078" offset="100%"/> </linearGradient> </defs><title>arrow-left icon</title>
         <path d="M15.27 5.095a2.985 2.985 0 0 0-4.22-4.22L0 11.923l11.036 11.187a2.985 2.985 0 1 0 4.25-4.192l-6.873-6.966 6.858-6.858z"/> 
      </svg>
     when "logo-badge"
      <svg xmlns="http://www.w3.org/2000/svg" class="i i-logo-badge" viewBox="0 0 68 68">
        <defs> <linearGradient x1="50.4%" y1="323.84%" x2="50.4%" y2="1.11%" id="a"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#0086CD" offset="100%"/> </linearGradient> <linearGradient x1="50.14%" y1="499.2%" x2="50.14%" y2="3.23%" id="b"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#556AB1" offset="100%"/> </linearGradient> <linearGradient x1="49.96%" y1="322.98%" x2="49.96%" y2="1.05%" id="c"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#8C288E" offset="100%"/> </linearGradient> <linearGradient x1="50.26%" y1="222.51%" x2="50.26%" y2="1%" id="d"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#00C0F3" offset="100%"/> </linearGradient> <linearGradient x1="50.28%" y1="205.24%" x2="50.28%" y2="-5.49%" id="e"> <stop stop-color="#FFF" offset="0%"/> <stop stop-color="#EA0078" offset="100%"/> </linearGradient> </defs><title>logo-badge icon</title>
          <g> <path d="M10 0h11v68H10z"/> <path d="M18 0h22v68H18z"/> <path d="M36 0h22v68H36z"/> <path d="M0 0h12v68H0z"/> <path d="M50 0h18v68H50z"/> <path d="M28.894 41.753v15.729H16.376v-7.247h4.53V17.706h-5.435v-7.247h13.505v27.506l15.483-15.647h8.153v7.329h-4.53L37.624 39.941l10.541 10.377h5.27v7.247h-8.976z"/> </g> 
      </svg>
```