### PR TITLE
Add xlink namespace to sprite if needed

### DIFF
--- a/templates/svg-symbols.svg
+++ b/templates/svg-symbols.svg
@@ -1,9 +1,36 @@
-<svg xmlns="http://www.w3.org/2000/svg"<% if(svgClassname) {%> class="<%= svgClassname %>"<% } %>><% if(defs) {%>
-  <defs>
-      <%= defs %>
-  </defs><% } %><% _.forEach( icons, function( icon ){ %>
-    <symbol id="<%= icon.id %>" viewBox="<%= icon.svg.viewBox %>"<% if (icon.svg.originalAttributes.preserveAspectRatio) {%> preserveAspectRatio="<%= icon.svg.originalAttributes.preserveAspectRatio %>" <% }%>><% if (icon.title) {%>
-      <title><%= icon.title %></title><% }%>
-      <%= icon.svg.content %>
-    </symbol><%
-}); %></svg>
+<%
+  function attrs(obj) {
+    return Object.getOwnPropertyNames(obj).reduce(function(str, key) {
+      var attr = key.replace(/[^a-zA-Z\-]/g, '');
+      var raw = obj[key], t = typeof raw;
+      if (t === 'string' || t === 'boolean' || (t === 'number' && !isNaN(raw))) {
+        return str + ' ' + attr + '="' + String(raw).replace(/"/g, '&quot;') + '"';
+      }
+      return str;
+    }, '');
+  }
+
+  function symbol(icon) {
+    var symbolAttrs = attrs({
+      id: icon.id,
+      viewBox: icon.svg.viewBox,
+      preserveAspectRatio: icon.svg.originalAttributes.preserveAspectRatio
+    });
+    var title = icon.title ? '<title>' + icon.title + '</title>' : '';
+    return '<symbol'+symbolAttrs+'>' + title + icon.svg.content + '</symbol>';
+  }
+
+  var symbols = icons.map(symbol).join('\n');
+  var haystack = symbols + (defs || '');
+  var svgAttrs = attrs({
+    'xmlns': 'http://www.w3.org/2000/svg',
+    'xmlns:xlink': /\sxlink:[a-z]+=/.test(haystack) ? 'http://www.w3.org/1999/xlink' : null,
+    'class': typeof svgClassname === 'string' ? svgClassname : null
+  });
+
+%><svg<%= svgAttrs %>>
+<% if (defs) { %><defs>
+<%= defs.trim() %>
+</defs>
+<% } %><%= symbols %>
+</svg>


### PR DESCRIPTION
I'm proposing this rewritten `templates/svg-symbols.svg` which has three improvements:

1. Fixes #34 by checking if the output (symbols and defs) uses the `xlink:` namespace, and outputs the corresponding xmlns attribute if it does. (Note that #34 also requires deplucating ids to avoid collisions, but as suggested it can and probably should be done with svgo beforehand.)

2. Avoids irregular indentation by keeping everything to the left, which in my experience makes it easy to identify symbols by their id (for minified symbols). One example from a production file using this template:

```svg
<svg xmlns="http://www.w3.org/2000/svg">
<symbol id="icon-angle" viewBox="0 0 14 14"><path d="M3 1l6 6-6 6 1 1 7-7-7-7-1 1z"/></symbol>
<symbol id="icon-cross" viewBox="0 0 34 34"><path d="M34 4l-4-4-13 13L4 0 0 4l13 13L0 30l4 4 13-13 13 13 4-4-13-13"/></symbol>
<symbol id="icon-file" viewBox="0 0 47 50"><path d="M35.002 18.07c.098 1.745-.492 3.442-1.727 4.678L15.568 40.454c-.366.366-.364 1.01.005 1.378.37.37 1.012.372 1.378.006l17.754-17.753c1.647-1.647 2.465-3.848 2.272-6.146l-.048-.506c-.337-4.09-3.657-7.226-7.7-7.334a7.941 7.941 0 0 0-5.824 2.32L5.834 29.99a11.223 11.223 0 0 0-3.273 8.438c.254 5.927 5.095 10.677 11.022 10.93h.184a11.27 11.27 0 0 0 8.347-3.274l20.27-20.27c2.973-2.973 4.473-7.055 4.18-11.282v-.184C46.028 7.134 40.217 1.324 33.05.744c-4.227-.292-8.4 1.207-11.375 4.18L.857 25.745c-.366.366-.364 1.01.005 1.378a.999.999 0 0 0 1.378.005L23.013 6.355c2.608-2.608 6.186-3.88 9.815-3.636 6.25.483 11.23 5.554 11.714 11.804v.183c.245 3.63-1.027 7.208-3.59 9.77L20.73 44.7c-1.83 1.83-4.354 2.786-6.926 2.684h-.184c-4.916-.158-8.882-4.124-9.13-9.04a9.406 9.406 0 0 1 2.728-6.97l17.57-17.57c1.143-1.145 2.795-1.78 4.402-1.73 3.032.105 5.57 2.457 5.81 5.536l.002.46z"/></symbol>
<symbol id="icon-menu" viewBox="0 0 20 17"><path d="M0 1h20v3H0V1zm0 6h20v3H0V7zm0 6h20v3H0v-3z"/></symbol>
</svg>
```

The overall template is quite a bit longer, partly because of the xlink check, and partly because of the helper `attrs(obj)` function that takes the start of the template. I find that it helps managing conditional attributes and avoid multiplying the `<% if(foo.bar.baz) {%> baz="<%= foo.bar.baz %>"<% } %>` conditions, but at the cost of some noise.

Finally, it's not in the scope of this PR but this opens a possibility for allowing arbitrary attributes on the root element. For instance you could add a `svgAttributes` option which takes an object, and the final attributes could be resolved in the template as:

```js
var rootAttrs = {
  'xmlns': 'http://www.w3.org/2000/svg',
  'xmlns:xlink': /\sxlink:[a-z]+=/.test(haystack) ? 'http://www.w3.org/1999/xlink' : null,
  'class': typeof svgClassname === 'string' ? svgClassname : null
};
if (svgAttributes) {
  Object.assign(rootAttrs, svgAttributes);
}
// output with <%= attrs(rootAttrs) %>
```